### PR TITLE
feat: allow 2-character usernames

### DIFF
--- a/src/utils/validate.rs
+++ b/src/utils/validate.rs
@@ -6,7 +6,7 @@ pub fn is_valid_id(id: &str) -> bool {
 }
 
 pub fn is_valid_username(name: &str) -> bool {
-    name.chars().all(|c| c.is_alphanumeric() || c == '-' || c == '_') && name.len() <= 64 && name.len() >= 3
+    name.chars().all(|c| c.is_alphanumeric() || c == '-' || c == '_') && name.len() <= 64 && name.len() >= 2
 }
 
 pub fn can_view_project(project: &Project, user: Option<&User>) -> bool {

--- a/web/src/components/settings/users/dialogs.tsx
+++ b/web/src/components/settings/users/dialogs.tsx
@@ -52,7 +52,7 @@ export const CreateUser = () => {
 					Username <small>(cannot be changed later)</small>
 					<input
 						required
-						pattern="^[A-Za-z0-9_\-]{1,20}$"
+						pattern="^[A-Za-z0-9_\-]{2,20}$"
 						name="username"
 						type="text"
 						placeholder="MyUsername"


### PR DESCRIPTION
e.g., initials

I'm not sure why the original minimum of 3 was chosen in ae4f898cd57c4ba5e2ccfaf4f410f99f818b4ed6, but it seems to be arbitrary, and reducing it doesn't break anything.

Thoughts?